### PR TITLE
Initialize MCP server with Go SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Model Context Protocol (MCP) server written in Go using the official MCP Go SDK v0.2.0. The server provides tools that can be used by MCP clients like Claude Desktop.
+
+## Build and Run Commands
+
+```bash
+# Build the server
+go build
+
+# Run the server (communicates via stdio)
+./everyday-mcp-server
+
+# Update dependencies
+go mod tidy
+```
+
+## Architecture
+
+The MCP server follows a simple architecture:
+
+- **Main Server**: Created using `mcp.NewServer()` with server metadata (name: "everyday", version: "1.0.0")
+- **Tool Registration**: Tools are defined with `mcp.Tool` structs and registered using `mcp.AddTool()`
+- **Tool Handlers**: Functions that implement the actual tool logic, following the signature `func(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[T]) (*mcp.CallToolResult, error)`
+- **Typed Arguments**: Tool arguments use Go structs with JSON and JSONSchema tags for validation
+- **Transport**: Uses stdio transport (`mcp.NewStdioTransport()`) for communication with MCP clients
+
+## Tool Development Pattern
+
+When adding new tools:
+
+1. Define argument struct with JSON and JSONSchema tags:
+   ```go
+   type ToolArgs struct {
+       Field string `json:"field" jsonschema:"description of field"`
+   }
+   ```
+
+2. Create tool handler function:
+   ```go
+   func toolHandler(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[ToolArgs]) (*mcp.CallToolResult, error) {
+       // Implementation
+       return &mcp.CallToolResult{
+           Content: []mcp.Content{
+               &mcp.TextContent{Text: "response"},
+           },
+       }, nil
+   }
+   ```
+
+3. Register tool in main():
+   ```go
+   toolDef := &mcp.Tool{
+       Name:        "tool-name",
+       Description: "Tool description",
+   }
+   mcp.AddTool(server, toolDef, toolHandler)
+   ```
+
+## MCP Client Configuration
+
+To use with Claude Desktop, add to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "everyday-server": {
+      "command": "/path/to/everyday-mcp-server",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/jgsheppa/everyday-mcp-server
+
+go 1.24.2
+
+require github.com/modelcontextprotocol/go-sdk v0.2.0
+
+require github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/modelcontextprotocol/go-sdk v0.2.0 h1:PESNYOmyM1c369tRkzXLY5hHrazj8x9CY1Xu0fLCryM=
+github.com/modelcontextprotocol/go-sdk v0.2.0/go.mod h1:0sL9zUKKs2FTTkeCCVnKqbLJTw5TScefPAzojjU459E=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type HiArgs struct {
+	Name string `json:"name" jsonschema:"the name to say hi to"`
+}
+
+func greetTool(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[HiArgs]) (*mcp.CallToolResult, error) {
+	name := params.Arguments.Name
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{	
+				Text: fmt.Sprintf("Moin moin %s!", name),
+			},
+		},
+	}, nil
+}
+
+func main() {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "everyday",
+		Version: "1.0.0",
+	}, nil)
+
+	greetToolDef := &mcp.Tool{
+		Name:        "moin",
+		Description: "Greets a person by name",
+	}
+
+	mcp.AddTool(server, greetToolDef, greetTool)
+
+	if err := server.Run(context.Background(), mcp.NewStdioTransport()); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add initial MCP server implementation using official Go SDK v0.2.0
- Create hello world server with greet tool that accepts name parameter
- Add CLAUDE.md documentation for future development guidance
- Configure Go module with required dependencies

## Test plan
- [ ] Build server successfully with `go build`
- [ ] Configure in `.mcp.json` for Claude Desktop integration
- [ ] Test greet tool functionality through MCP client

🤖 Generated with [Claude Code](https://claude.ai/code)