### PR TITLE
Fix MCP tool naming convention to resolve client validation error

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "everyday",
-		Version: "1.0.0",
+		Version: "1.1.0",
 	}, nil)
 
 	tools.AddFrenchTool(server)

--- a/pkg/tools/french.go
+++ b/pkg/tools/french.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -31,12 +32,19 @@ func FrenchGreeting(
 }
 
 func NewFrenchGreetingTool() *Config[FrenchGreetingArgs] {
+	definition := mcp.Tool{
+		Name:        "french_greeting",
+		Description: "Says \"Bonjour\" to someone by name",
+	}
+
+	err := ValidateToolName(definition.Name)
+	if err != nil {
+		log.Fatalf("invalid tool name")
+	}
+
 	return &Config[FrenchGreetingArgs]{
-		Definition: &mcp.Tool{
-			Name:        "french_greeting",
-			Description: "Says \"Bonjour\" to someone by name",
-		},
-		Call: FrenchGreeting,
+		Definition: &definition,
+		Call:       FrenchGreeting,
 	}
 }
 

--- a/pkg/tools/french.go
+++ b/pkg/tools/french.go
@@ -31,9 +31,11 @@ func FrenchGreeting(
 }
 
 func NewFrenchGreetingTool() *Config[FrenchGreetingArgs] {
-	return &Config[FrenchGreetingArgs]{Definition: &mcp.Tool{
-		Name:        "French Greeting",
-		Description: "Says \"Bonjour\" to someone by name"},
+	return &Config[FrenchGreetingArgs]{
+		Definition: &mcp.Tool{
+			Name:        "french_greeting",
+			Description: "Says \"Bonjour\" to someone by name",
+		},
 		Call: FrenchGreeting,
 	}
 }

--- a/pkg/tools/german.go
+++ b/pkg/tools/german.go
@@ -31,9 +31,11 @@ func GermanGreeting(
 }
 
 func NewGermanGreetingTool() *Config[GermanGreetingArgs] {
-	return &Config[GermanGreetingArgs]{Definition: &mcp.Tool{
-		Name:        "German greeting",
-		Description: "Says \"Moin moin\" to someone by name"},
+	return &Config[GermanGreetingArgs]{
+		Definition: &mcp.Tool{
+			Name:        "german_greeting",
+			Description: "Says \"Moin moin\" to someone by name",
+		},
 		Call: GermanGreeting,
 	}
 }

--- a/pkg/tools/german.go
+++ b/pkg/tools/german.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -31,12 +32,18 @@ func GermanGreeting(
 }
 
 func NewGermanGreetingTool() *Config[GermanGreetingArgs] {
+	definition := mcp.Tool{
+		Name:        "german_greeting",
+		Description: "Says \"Moin moin\" to someone by name",
+	}
+	err := ValidateToolName(definition.Name)
+	if err != nil {
+		log.Fatalf("invalid tool name")
+	}
+
 	return &Config[GermanGreetingArgs]{
-		Definition: &mcp.Tool{
-			Name:        "german_greeting",
-			Description: "Says \"Moin moin\" to someone by name",
-		},
-		Call: GermanGreeting,
+		Definition: &definition,
+		Call:       GermanGreeting,
 	}
 }
 

--- a/pkg/tools/tool.go
+++ b/pkg/tools/tool.go
@@ -2,11 +2,22 @@ package tools
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+var toolNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]{1,64}$`)
+
 type Config[T any] struct {
 	Definition *mcp.Tool
 	Call       func(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[T]) (*mcp.CallToolResult, error)
+}
+
+func ValidateToolName(name string) error {
+	if !toolNameRegex.MatchString(name) {
+		return fmt.Errorf("tool name '%s' must match regex [a-zA-Z0-9_]{1,64}", name)
+	}
+	return nil
 }

--- a/pkg/tools/tool_test.go
+++ b/pkg/tools/tool_test.go
@@ -1,0 +1,109 @@
+package tools_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jgsheppa/everyday-mcp-server/pkg/tools"
+)
+
+func TestValidateToolName(t *testing.T) {
+	tests := []struct {
+		name    string
+		toolName string
+		wantErr bool
+	}{
+		{
+			name:     "valid tool name with underscores",
+			toolName: "french_greeting",
+			wantErr:  false,
+		},
+		{
+			name:     "valid tool name with numbers",
+			toolName: "tool123",
+			wantErr:  false,
+		},
+		{
+			name:     "valid tool name mixed case",
+			toolName: "MyTool_123",
+			wantErr:  false,
+		},
+		{
+			name:     "valid single character",
+			toolName: "a",
+			wantErr:  false,
+		},
+		{
+			name:     "valid 64 character name",
+			toolName: strings.Repeat("a", 64),
+			wantErr:  false,
+		},
+		{
+			name:     "invalid empty name",
+			toolName: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid name with spaces",
+			toolName: "French Greeting",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid name with hyphens",
+			toolName: "french-greeting",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid name with special characters",
+			toolName: "french@greeting",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid name too long (65 chars)",
+			toolName: strings.Repeat("a", 65),
+			wantErr:  true,
+		},
+		{
+			name:     "invalid name with dots",
+			toolName: "french.greeting",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tools.ValidateToolName(tt.toolName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateToolName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExistingToolNamesValid(t *testing.T) {
+	frenchTool := tools.NewFrenchGreetingTool()
+	germanTool := tools.NewGermanGreetingTool()
+
+	tests := []struct {
+		name     string
+		toolName string
+	}{
+		{
+			name:     "french greeting tool name",
+			toolName: frenchTool.Definition.Name,
+		},
+		{
+			name:     "german greeting tool name",
+			toolName: germanTool.Definition.Name,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tools.ValidateToolName(tt.toolName)
+			if err != nil {
+				t.Errorf("existing tool name '%s' failed validation: %v", tt.toolName, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix tool names to use underscore convention instead of spaces
- Change "French Greeting" → "french_greeting"
- Change "German greeting" → "german_greeting"  
- Update server version to 1.1.0
- Improve code formatting consistency

This resolves the `tools.0.FrontendRemoteMcpToolDefinition.name` validation error in Claude client by ensuring tool names follow proper identifier conventions without spaces.

## Test plan
- [ ] Build and run the MCP server
- [ ] Test tool registration in Claude Desktop
- [ ] Verify tools can be called successfully
- [ ] Confirm no more naming validation errors

🤖 Generated with [Claude Code](https://claude.ai/code)